### PR TITLE
Fix broken image and upgrade HTTP links to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,22 +103,22 @@
           <p>Here are some of the companies and projects I've worked on as part of my career</p>
           <ul class="nav nav-pills flex-column">
             <li class="nav-item">
-              <a class="nav-link active" href="http://www.google.com">Google</a>
+              <a class="nav-link active" href="https://www.google.com">Google</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="http://www.accenture.com">Accenture</a>
+              <a class="nav-link" href="https://www.accenture.com">Accenture</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="http://www.microsoft.com">Microsoft</a>
+              <a class="nav-link" href="https://www.microsoft.com">Microsoft</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="http://www.pfizer.com">Pfizer</a>
+              <a class="nav-link" href="https://www.pfizer.com">Pfizer</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="http://www.smart.com.ph">Smart Communications</a>
+              <a class="nav-link" href="https://www.smart.com.ph">Smart Communications</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link disabled" href="http://perpetualsystems.net">Perpetual Systems</a>
+              <a class="nav-link disabled" href="https://perpetualsystems.net">Perpetual Systems</a>
             </li>
           </ul>
           <hr class="d-sm-none">
@@ -134,7 +134,7 @@
           <br>
           <h2>Look am a Korean TV Star! </h2>
           <h5>Google Cloud On-Air, Sep 2, 2017</h5>
-          <div class="fakeimg" align="center"><img src="http://34.107.142.189/images/GoogleCloud-Logo.gif" height="190px"> <img src="https://storage.googleapis.com/johnnyb-web1/images/Cloud%20On%20Air%20(2019-03-28).png" height="200px" alt="Screen cap of Cloud On Air Korea"></div>
+          <div class="fakeimg" align="center"> <img src="https://storage.googleapis.com/johnnyb-web1/images/Cloud%20On%20Air%20(2019-03-28).png" height="200px" alt="Screen cap of Cloud On Air Korea"></div>
           <p>Johnny giving  a talk about serverless technologies for Google Cloud On Air Korea</p>
           <p> I'm glad that my talk on building a <a href="https://cloudonair.withgoogle.com/events/app-dev/schedule?talk=apac-track1-gcp"> Serverless Beyond GCP: Taking Advantage of Google and Third-Party Services </a> was also broadcasted to a Korean audience. It was nice to see some Korean subtitles to my talk and this made me feel like I was a guest actor on a Korean TV show. My talk was about how to use 3rd party services such as SMS, Online Payment Gateways and even Google Assistant to help improve your web site. I even got to do a live demo where I used a Google Home to interact with my web site in real time.</p>
         </div>


### PR DESCRIPTION
I have implemented improvements to the website:
1.  **Removed Broken and Insecure Image:** I removed an image tag in `index.html` that was pointing to an insecure, hardcoded IP address (`http://34.107.142.189/images/GoogleCloud-Logo.gif`) which was returning a 404 error and could cause mixed-content issues.
2.  **Upgraded Links to HTTPS:** I updated all the external company links in the "My Favorite Projects" section of `index.html` from `http://` to `https://` (e.g., Google, Microsoft, Accenture). This ensures links are secure.

---
*PR created automatically by Jules for task [3061178808443099778](https://jules.google.com/task/3061178808443099778) started by @JohnnyB95*